### PR TITLE
Do not rewrite existing vcard and respect explicit output name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "vcard-qr"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vcard-qr"
 authors = ["SomewhereOutInSpace", "melonion"]
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Generate basic vCard QR codes from the command line."
 repository  = "https://github.com/SomewhereOutInSpace/vcard-qr"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,8 @@ use qrcode_generator::QrCodeEcc;
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// The desired name of the output file, sans extension.
-    #[arg(short, long, default_value = "vcard")]
-    pub output_name: String,
+    #[arg(short, long)]
+    pub output_name: Option<String>,
     /// Whether or not to prefix the output filename with the VCard's FN (formatted name) field.
     #[arg(short, long)]
     pub prefix_name: bool,


### PR DESCRIPTION
defaulting to the vcard name makes sense, but explicit output name should still be respected